### PR TITLE
Change archive name to buildcraft-remastered

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -65,7 +65,7 @@ if (System.getenv("BUILD_VARIANT") != null) {
 
 version = config.mod_version
 group= "com.mod-buildcraft"
-archivesBaseName = "buildcraft" // the name that all artifacts will use as a base. artifacts names follow this pattern: [baseName]-[appendix]-[version]-[classifier].[extension]
+archivesBaseName = "buildcraft-remastered" // the name that all artifacts will use as a base. artifacts names follow this pattern: [baseName]-[appendix]-[version]-[classifier].[extension]
 
 ext.mcModInfo = new groovy.json.JsonSlurper().parse(file("buildcraft_resources/mcmod.info"))
 ext.priv = parseConfig(file('private.properties'))

--- a/buildcraft_resources/mcmod.info
+++ b/buildcraft_resources/mcmod.info
@@ -1,7 +1,7 @@
 [
 {
   "modid": "buildcraftlib",
-  "name": "BuildCraft Lib",
+  "name": "BuildCraft (Remastered) Lib",
   "version": "$version",
   "mcversion": "${mcversion}",
   "description": "Library mod used by buildcraft.",
@@ -18,7 +18,7 @@
 },
 {
   "modid": "buildcraftcore",
-  "name": "BuildCraft",
+  "name": "BuildCraft (Remastered)",
   "version": "$version",
   "mcversion": "${mcversion}",
   "description": "Extending Minecraft with pipes, auto-crafting, quarries, engines and much more!",
@@ -35,7 +35,7 @@
 },
 {
   "modid": "buildcraftbuilders",
-  "name": "BuildCraft Builders",
+  "name": "BuildCraft (Remastered) Builders",
   "version": "$version",
   "mcversion": "${mcversion}",
   "description": "Extending Minecraft with pipes, auto-crafting, quarries, engines and much more! (Builders Component)",
@@ -52,7 +52,7 @@
 },
 {
   "modid": "buildcraftenergy",
-  "name": "BuildCraft Energy",
+  "name": "BuildCraft (Remastered) Energy",
   "version": "$version",
   "mcversion": "${mcversion}",
   "description": "Extending Minecraft with pipes, auto-crafting, quarries, engines and much more! (Energy Component)",
@@ -69,7 +69,7 @@
 },
 {
   "modid": "buildcraftfactory",
-  "name": "BuildCraft Factory",
+  "name": "BuildCraft (Remastered) Factory",
   "version": "$version",
   "mcversion": "${mcversion}",
   "description": "Extending Minecraft with pipes, auto-crafting, quarries, engines and much more! (Factory Component)",
@@ -86,7 +86,7 @@
 },
 {
   "modid": "buildcraftsilicon",
-  "name": "BuildCraft Silicon",
+  "name": "BuildCraft (Remastered) Silicon",
   "version": "$version",
   "mcversion": "${mcversion}",
   "description": "Extending Minecraft with pipes, auto-crafting, quarries, engines and much more! (Silicon Component)",
@@ -103,7 +103,7 @@
 },
 {
   "modid": "buildcrafttransport",
-  "name": "BuildCraft Transport",
+  "name": "BuildCraft (Remastered) Transport",
   "version": "$version",
   "mcversion": "${mcversion}",
   "description": "Extending Minecraft with pipes, auto-crafting, quarries, engines and much more! (Transport Component)",
@@ -120,7 +120,7 @@
 },
 {
   "modid": "buildcraftrobotics",
-  "name": "BuildCraft Robotics",
+  "name": "BuildCraft (Remastered) Robotics",
   "version": "$version",
   "mcversion": "${mcversion}",
   "description": "Extending Minecraft with pipes, auto-crafting, quarries, engines and much more! (Robotics Component)",

--- a/common/buildcraft/lib/BCLib.java
+++ b/common/buildcraft/lib/BCLib.java
@@ -73,7 +73,7 @@ public class BCLib {
         } catch (NoSuchFieldError e) {
             throw throwBadClass(e, BCLog.class);
         }
-        BCLog.logger.info("Starting BuildCraft " + BCLib.VERSION);
+        BCLog.logger.info("Starting BuildCraft Remastered " + BCLib.VERSION);
         BCLog.logger.info("Copyright (c) the BuildCraft team, 2011-2018");
         BCLog.logger.info("https://www.mod-buildcraft.com");
         if (!GIT_COMMIT_HASH.startsWith("${")) {


### PR DESCRIPTION
This results in an output jar named like `buildcraft-remastered-main-8.0.2.jar`, which helps to differentiate this fork from upstream.
I've also added the fork name to the main log message.

(As a side note, if you build with `gradle build -Drelease=true` it will not include the commit hash in the version)